### PR TITLE
Added alt text to make Buy Now button HTML5 validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ Documentation
 * Found a problem?  Have a suggestion?  Please discuss it on the [Lift mailing list](https://groups.google.com/group/liftweb) before raising a ticket.
 
 
+Customization
+=============
+
+
+Alt text
+--------
+
+To customize the alt text of the buy now button, set up a [resources entry](https://www.assembla.com/spaces/liftweb/wiki/Localization) for the key _liftmodules.paypal.button-alt-text_. For example, create _webapp/\_resources.html_, with the following content:
+
+    <?xml version="1.0"?>
+    <resources>
+      <res name="liftmodules.paypal.button-alt-text">Place order now</res>
+    </resources>
+
+
 Notes for module developers
 ===========================
 

--- a/src/main/scala/net/liftmodules/paypal/snippet/BuyNow.scala
+++ b/src/main/scala/net/liftmodules/paypal/snippet/BuyNow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2013 WorldWide Conferencing, LLC
+ * Copyright 2007-2014 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,32 +16,33 @@
 
 package net.liftmodules.paypal {
 package snippet {
-  
-  import scala.xml.NodeSeq
+
+  import scala.xml.{Text,NodeSeq}
   import net.liftmodules.paypal.PaypalRules
-  import net.liftweb.http.{DispatchSnippet}
-  
+  import net.liftweb.http.{S,DispatchSnippet}
+
   trait BuyNowSnippet extends DispatchSnippet {
     def dispatch = {
       case _ => buynow _
     }
-    
+
     def amount: Double
-    
+
     def values: Map[String,String] = Map()
-    
-    def buynow(xhtml: NodeSeq): NodeSeq = 
-      <form name="_xclick" 
-            action={PaypalRules.connection.vend().protocol+"://"+PaypalRules.mode.vend().domain+"/cgi-bin/webscr"} 
+
+    def buynow(xhtml: NodeSeq): NodeSeq =
+      <form name="_xclick"
+            action={PaypalRules.connection.vend().protocol+"://"+PaypalRules.mode.vend().domain+"/cgi-bin/webscr"}
             method="post">
         <input type="hidden" name="cmd" value="_xclick" />
         <input type="hidden" name="amount" value={amount.toString} />
         <input type="hidden" name="currency_code" value={PaypalRules.currency.vend()} />
         { values.-("amount","currency_code","cmd","submit")
             .map(x => <input type="hidden" name={x._1} value={x._2} />) }
-        <input type="image" src={PaypalRules.button.vend()} name="submit" alt="" />
+        <input type="image" src={PaypalRules.button.vend()} name="submit" alt={altText} />
       </form>
-      
+
+    lazy val altText: NodeSeq = S.loc("liftmodules.paypal.button-alt-text") openOr Text("Buy Now")
   }
-  
+
 }}


### PR DESCRIPTION
In relation to #1, this PR adds a populated `alt` tag to the Buy Now button so it validates as HTML5:

![form submission - w3c markup validator 2014-08-18 17-32-50](https://cloud.githubusercontent.com/assets/102661/3993739/d59fabec-2910-11e4-8edd-0e574d6348a3.png)

The default text is "Buy Now", but this can be customized by providing an alternative value for the key. E.g: in _src/main/webapp/_resources.html_:

``` xml
<resources>
  <res name="liftmodules.paypal.button-alt-text">Place order now</res>
</resources>
```
